### PR TITLE
Added support for requireJs 'define'.

### DIFF
--- a/js/tmpl.js
+++ b/js/tmpl.js
@@ -76,8 +76,9 @@
     tmpl.arg = "o";
     tmpl.helper = ",print=function(s,e){_s+=e&&(s||'')||_e(s);}" +
         ",include=function(s,d){_s+=tmpl(s,d);}";
-    if (typeof define === "function" && define.amd) {
-        define(function () {
+    // requireJS/Almond module definition
+    if(typeof window.define === 'function' && window.define.amd) {
+        window.define('tmpl', [], function() {
             return tmpl;
         });
     } else {


### PR DESCRIPTION
Hello,

While working with the script I got the following error:

```
Uncaught TypeError: Cannot read property 'splice' of undefined almond.min.js:216
define almond.min.js:216
(anonymous function) tmpl.js:44
(anonymous function) tmpl.js:47
.............
(anonymous function) tmpl.js:10
```

As it turned out, Almond's/requireJs's define() function takes 3 params:
`function (name,deps,callback)`

Javascript-Templates's current implementation only passes the callback. Thus define() tries to use it as a name(first argument). To fix the problem, we need to pass all three parameters, just like I propose in my pull request:

```
window.define('tmpl', [], function() { // name, deps, callback
```

Hopefully, this will fix problem not only for me, but for the other people who uses the library. Wish you good luck!

Also, before seding pull request I wanted to run tests(yeah, this change is relatively small but still...) - to check everything's going well. README file doesn't contain info/command for this. It would be easier if you included this.

Thanks.
