### PR TITLE
Exposing license information according to bower format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,7 @@
     "url": "git://github.com/blueimp/JavaScript-Templates.git"
   },
   "bugs": "https://github.com/blueimp/JavaScript-Templates/issues",
-  "license": "MIT"
-  ],
+  "license": "MIT",
   "main": "js/tmpl.js",
   "ignore": [
     "/*.*",

--- a/bower.json
+++ b/bower.json
@@ -24,11 +24,7 @@
     "url": "git://github.com/blueimp/JavaScript-Templates.git"
   },
   "bugs": "https://github.com/blueimp/JavaScript-Templates/issues",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
+  "license": "MIT"
   ],
   "main": "js/tmpl.js",
   "ignore": [


### PR DESCRIPTION
`license` field should contain String or Array of Strings. See: http://bower.io/docs/creating-packages/

Current format doesn't work with libraries that inspect and generate information about all the libraries used in the project (e.g. `grunt-license-bower`).