### PR TITLE
Fix the spelling of 'Skip'

### DIFF
--- a/js/compile.js
+++ b/js/compile.js
@@ -49,7 +49,7 @@
             content,
             result,
             id;
-        // Skipt the first two arguments, which are "node" and the script:
+        // Skip the first two arguments, which are "node" and the script:
         if (index > 1) {
             stats = fs.statSync(file);
             if (!stats.isFile()) {


### PR DESCRIPTION
Fixed the spelling of 'Skip' on line 52