### PR TITLE
Don't force minification upon the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ This will put the executable **tmpl.js** into the folder
 install the packages globally (by adding the **-g** flag to the install command).
 
 The **tmpl.js** executable accepts the paths to one or multiple template files
-as command line arguments and saves the generated JavaScript code to a file named **compiled_template.js** in the current working directory:
+as command line arguments and saves the generated JavaScript code to **output.js** in the current working directory:
 
 ```sh
 tmpl.js templates/upload.html templates/download.html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ loaders like RequireJS, Browserify or webpack and all web browsers.
 ## Usage
 
 ### Client-side
-Include the (minified) JavaScript Templates script in your HTML markup:
+Include the JavaScript Templates script in your HTML markup:
 
 ```html
 <script src="js/tmpl.min.js"></script>
@@ -354,19 +354,17 @@ The JavaScript Templates project comes with a compilation script, that allows
 you to compile your templates into JavaScript code and combine them with a
 minimal Templates runtime into one minified JavaScript file.
 
-The compilation script is built for [node.js](http://nodejs.org/) and also
-requires [UglifyJS](https://github.com/mishoo/UglifyJS).  
-To use it, first install both the JavaScript Templates project and UglifyJS via
+The compilation script is built for [node.js](http://nodejs.org/). 
+To use it, first install the JavaScript Templates project via
 [npm](https://www.npmjs.org/):
 
 ```sh
-npm install uglify-js blueimp-tmpl
+npm install blueimp-tmpl
 ```
 
-This will put the executables **uglifyjs** and **tmpl.js** into the folder
-**node_modules/.bin**. It will also make them available on your PATH if you
-install the packages globally
-(by adding the **-g** flag to the install command).
+This will put the executable **tmpl.js** into the folder
+**node_modules/.bin**. It will also make it available on your PATH if you
+install the packages globally (by adding the **-g** flag to the install command).
 
 The **tmpl.js** executable accepts the paths to one or multiple template files
 as command line arguments and prints the generated JavaScript code to the

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ This will put the executable **tmpl.js** into the folder
 install the packages globally (by adding the **-g** flag to the install command).
 
 The **tmpl.js** executable accepts the paths to one or multiple template files
-as command line arguments and saves the generated JavaScript code to a file named **compiled_template.js** in the current directory:
+as command line arguments and saves the generated JavaScript code to a file named **compiled_template.js** in the current working directory:
 
 ```sh
 tmpl.js templates/upload.html templates/download.html

--- a/README.md
+++ b/README.md
@@ -367,12 +367,10 @@ This will put the executable **tmpl.js** into the folder
 install the packages globally (by adding the **-g** flag to the install command).
 
 The **tmpl.js** executable accepts the paths to one or multiple template files
-as command line arguments and prints the generated JavaScript code to the
-console output. The following command line shows you how to store the generated
-code in a new JavaScript file that can be included in your project:
+as command line arguments and saves the generated JavaScript code to a file named **compiled_template.js** in the current directory:
 
 ```sh
-tmpl.js templates/upload.html templates/download.html > tmpl.min.js
+tmpl.js templates/upload.html templates/download.html
 ```
 
 The files given as command line arguments to **tmpl.js** can either be pure

--- a/js/compile.js
+++ b/js/compile.js
@@ -78,6 +78,12 @@
   }
   // Combine the generated functions as cache of the minimal runtime:
   code = runtime.replace('{}', '{' + list.join(',') + '}')
-  // Generate the minified code and print it to the console output:
-  console.log(uglifyJS.minify(code, {fromString: true}).code)
+  // Write the cmpiled code to an arbitrary outfile:
+    fs.writeFile(path.join(__dirname, 'compiled_template.js'), code, function(err) {
+    if(err) {
+	return console.log(err);
+    }
+
+    console.log("The file was saved successfully.");
+  }); 
 }())

--- a/js/compile.js
+++ b/js/compile.js
@@ -78,7 +78,7 @@
   // Combine the generated functions as cache of the minimal runtime:
   code = runtime.replace('{}', '{' + list.join(',') + '}')
   // Write the compiled code to an arbitrary outfile:
-    fs.writeFile(path.join(__dirname, 'compiled_template.js'), code, function(err) {
+    fs.writeFile(path.join(process.cwd(), 'output.js'), code, function(err) {
     if(err) {
 	return console.log(err);
     }

--- a/js/compile.js
+++ b/js/compile.js
@@ -77,7 +77,7 @@
   }
   // Combine the generated functions as cache of the minimal runtime:
   code = runtime.replace('{}', '{' + list.join(',') + '}')
-  // Write the cmpiled code to an arbitrary outfile:
+  // Write the compiled code to an arbitrary outfile:
     fs.writeFile(path.join(__dirname, 'compiled_template.js'), code, function(err) {
     if(err) {
 	return console.log(err);

--- a/js/compile.js
+++ b/js/compile.js
@@ -17,7 +17,6 @@
   var path = require('path')
   var tmpl = require(path.join(__dirname, 'tmpl.js'))
   var fs = require('fs')
-  var uglifyJS = require('uglify-js')
   // Retrieve the content of the minimal runtime:
   var runtime = fs.readFileSync(path.join(__dirname, 'runtime.js'), 'utf8')
   // A regular expression to parse templates from script tags in a HTML page:


### PR DESCRIPTION
Uglify-JS can cause problems which are not related to the templating itself. This basically boils down to having a third-party script breaking the main function of JavaScript-Templates. Better leave it to the end users to decide what to do with their compiled JS code.